### PR TITLE
fix set_variable for globals

### DIFF
--- a/src/debugger_requests.jl
+++ b/src/debugger_requests.jl
@@ -642,7 +642,7 @@ function set_variable_request(conn, state::DebuggerState, params::SetVariableArg
 
             return SetVariableResponseArguments(s.value, s.type, s.variablesReference, s.namedVariables, s.indexedVariables)
         catch err
-            return JSONRPC.JSONRPCError(-32600, "Something went wrong in the set: $err", nothing)
+            return JSONRPC.JSONRPCError(-32600, "Something went wrong while setting the variable: $err", nothing)
         end
     elseif var_ref.kind == :var
         if isnumeric(var_name[1])
@@ -661,7 +661,7 @@ function set_variable_request(conn, state::DebuggerState, params::SetVariableArg
 
                 return SetVariableResponseArguments(s.value, s.type, s.variablesReference, s.namedVariables, s.indexedVariables)
             catch err
-                return JSONRPC.JSONRPCError(-32600, "Something went wrong in the set: $err", nothing)
+                return JSONRPC.JSONRPCError(-32600, "Something went wrong while setting the variable: $err", nothing)
             end
         else
             if Base.isimmutable(var_ref.value)
@@ -680,7 +680,7 @@ function set_variable_request(conn, state::DebuggerState, params::SetVariableArg
 
                     return SetVariableResponseArguments(s.value, s.type, s.variablesReference, s.namedVariables, s.indexedVariables)
                 catch err
-                    return JSONRPC.JSONRPCError(-32600, "Something went wrong in the set: $err", nothing)
+                    return JSONRPC.JSONRPCError(-32600, "Something went wrong while setting the variable: $err", nothing)
                 end
             end
         end
@@ -693,10 +693,14 @@ function set_variable_request(conn, state::DebuggerState, params::SetVariableArg
             return JSONRPC.JSONRPCError(-32600, "No module attached to this global variable.", nothing)
         end
 
+        if !(mod isa Base.Module)
+            return JSONRPC.JSONRPCError(-32600, "Can't determine the module this variable is defined in.", nothing)
+        end
+
         new_val = try
             mod.eval(Meta.parse("$var_name = $var_value"))
         catch err
-            return JSONRPC.JSONRPCError(-32600, "Something went wrong in the set: $err", nothing)
+            return JSONRPC.JSONRPCError(-32600, "Something went wrong while setting the variable: $err", nothing)
         end
         s = construct_return_msg_for_var(state::DebuggerState, "", new_val)
 


### PR DESCRIPTION
I forgot about this in #9, so `set_variable` requests throw an error when trying to modify a global. This PR implements the missing logic.