### PR TITLE
Set SOURCE_PATH for the correct task

### DIFF
--- a/src/debugger_requests.jl
+++ b/src/debugger_requests.jl
@@ -17,7 +17,7 @@ function debug_notification(conn, state::DebuggerState, params::DebugArguments)
 
     @debug "We are debugging the file $filename_to_debug."
 
-    task_local_storage()[:SOURCE_PATH] = filename_to_debug
+    put!(state.next_cmd, (cmd = :set_source_path, source_path = filename_to_debug))
 
     ex = _parse_julia_file(filename_to_debug)
 

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -95,6 +95,8 @@ function startdebug(socket, error_handler = nothing)
                     break
                 elseif msg.cmd == :stop
                     break
+                elseif msg.cmd == :set_source_path
+                    task_local_storage()[:SOURCE_PATH] = msg.source_path
                 else
                     ret = if msg.cmd == :continue
                         our_debug_command(:c, state)


### PR DESCRIPTION
I forgot to adjust this when I moved things to a two task model. So what happens in the currently shipping version is that no `include` statement with a relative path works in the F5 mode... This fixes things.

I think we should try to push out a patch release ASAP with this, so as soon as someone has reviewed this I'll release an insider release with this and then hopefully to everyone soon after.

Fixes https://discourse.julialang.org/t/vs-code-debugger-include-bar-jl-paused-on-exception/42779.