### PR TITLE
Run user code in the Main module for the debugger run scenario

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -86,7 +86,7 @@ function startdebug(socket, error_handler = nothing)
 
                 if msg.cmd == :run
                     try
-                        include(msg.program)
+                        Core.eval(Main, :(include($(msg.program))))
                     catch err
                         Base.display_error(stderr, err, catch_backtrace())
                     end

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -86,7 +86,7 @@ function startdebug(socket, error_handler = nothing)
 
                 if msg.cmd == :run
                     try
-                        Core.eval(Main, :(include($(msg.program))))
+                        Main.include(msg.program)
                     catch err
                         Base.display_error(stderr, err, catch_backtrace())
                     end


### PR DESCRIPTION
We get warning messages right now if a user script does any `using Foo`, because that code will be run inside `VSCodeDebugger` and that package of course doesn't have `Foo` in its deps.