### PR TITLE
Do not use a constructor that does not exist on 1.0

### DIFF
--- a/src/debugger_core.jl
+++ b/src/debugger_core.jl
@@ -17,7 +17,7 @@ mutable struct DebuggerState
     next_cmd::Channel{Any}
 
     function DebuggerState()
-        return new(nothing, [], 0, nothing, Set{String}(), :unknown, JuliaInterpreter.finish_and_return!, Dict{Int,String}(), 1, VariableReference[], Channel{Any}())
+        return new(nothing, [], 0, nothing, Set{String}(), :unknown, JuliaInterpreter.finish_and_return!, Dict{Int,String}(), 1, VariableReference[], Channel{Any}(Inf))
     end
 end
 


### PR DESCRIPTION
This fixes a bug from crash reporting on Julia 1.0.

This _also_ changes the channel from a blocking one to one with a queue. I meant to use that one in the first place, didn't realize that the default is a blocking one.