### PR TITLE
better printing for "step into targets"

### DIFF
--- a/src/debugger_utils.jl
+++ b/src/debugger_utils.jl
@@ -43,7 +43,7 @@ function calls_on_line(frame::JuliaInterpreter.Frame, line = nothing)
             for i in 1:length(expr.args)
                 expr.args[i] = maybe_quote(expr.args[i])
             end
-            push!(exprs, (pc = pc, expr = prettyprint_expr(expr, src)))
+            push!(exprs, (pc = pc, expr = string("%", pc, " = ", prettyprint_expr(expr, src))))
         elseif Meta.isexpr(expr, :(=))
             expr = expr.args[2]
             push!(exprs, (pc = pc, expr = prettyprint_expr(expr, src)))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6735977/89203130-524f9c00-d5b4-11ea-9b8c-51bed7627089.png)

It might make sense to show this *with* the SSA targets (e.g. `%3 = cos(x)` etc) so it's more obvious what's being evaluated. Thoughts?

Fixes #14.