### PR TITLE
clear varrefs in scope request

### DIFF
--- a/src/debugger_core.jl
+++ b/src/debugger_core.jl
@@ -60,7 +60,6 @@ function get_next_top_level_frame(state)
 end
 
 function our_debug_command(cmd, state)
-    empty!(state.varrefs)
     while true
         @debug "Running a new frame." state.frame state.compile_mode
 

--- a/src/debugger_requests.jl
+++ b/src/debugger_requests.jl
@@ -353,6 +353,7 @@ end
 
 function scopes_request(conn, state::DebuggerState, params::ScopesArguments)
     @debug "getscope_request"
+    empty!(state.varrefs)
 
     curr_fr = JuliaInterpreter.leaf(state.frame)
 


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/1941. `empty!`ing  `state.varrefs` should happen when generating new ones, because we aren't guaranteed that all `variablesRequests` finish before stepping (which is triggered by the user).

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
