### PR TITLE
fix toplevel step-into-target

### DIFF
--- a/src/debugger_utils.jl
+++ b/src/debugger_utils.jl
@@ -34,7 +34,7 @@ function calls_on_line(frame::JuliaInterpreter.Frame, line=nothing)
             return exprs
         end
 
-        expr = JuliaInterpreter.pc_expr(src, pc)
+        expr = deepcopy(JuliaInterpreter.pc_expr(src, pc))
         if Meta.isexpr(expr, :call)
             for i in 1:length(expr.args)
                 expr.args[i] = maybe_quote(expr.args[i])


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/1993.

Turns out my `calls_on_line` implementation accidentally modified the `frame`, which caused an error when running the code (because the `GlobalRef`s were replaced by `Symbol`s), which in turn caused us to endlessly iterate in the `:stepIn` request, because that didn't handle breakpoints properly...

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
