### PR TITLE
stop deadlocking and fix return type

### DIFF
--- a/src/debugger_requests.jl
+++ b/src/debugger_requests.jl
@@ -928,7 +928,7 @@ end
 
     put!(state.next_cmd, (cmd = :continue,))
 
-    return ContinueResponseArguments()
+    return ContinueResponseArguments(true)
 end
 
 function next_request(conn, state::DebuggerState, params::NextArguments)

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -144,15 +144,9 @@ function startdebug(socket, error_handler=nothing)
                 end
             end
 
-            # Wait until we have sent any response to currently handled
-            # messages before we shutdown
-            while JSONRPC.is_currently_handling_msg(msg_dispatcher)
-                yield()
-            end
-
             @debug "Finished debugging"
         finally
-            close(endpoint)
+            close(socket)
         end
     catch err
         if error_handler === nothing


### PR DESCRIPTION
Fixes two issues with the debugger:
1. `ContinueResponseArguments` didn't get serialized correctly without the proper argument.
2. We'd sometimes deadlock in that `yield` loop. So now we just close the pipe and are done with the world. Bit of a nuclear option but fixes things until we can figure out how to properly flush.
