### PR TITLE
Clean up launch related args

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DebugAdapter"
 uuid = "17994d07-08fe-42cc-bc1b-7af499b1ea47"
-version = "2.0.1-DEV"
+version = "3.0.0-DEV"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The call to `run` will return once the debug session has finished.
 
 ## Julia specific launch and attach arguments
 
-The Julia specific launch arguments can be seen in the type `LaunchArguments` in this repo. The most important one is `program`, which needs to be an absolute path to a Julia file.
+The Julia specific launch arguments can be seen in the type `JuliaLaunchArguments` in this repo. The most important one is `program`, which needs to be an absolute path to a Julia file.
 
 The Julia specific attach arguments can be seen in the type `JuliaAttachArguments` in this repo. Note that even when the debugger is attached, no code will automatically be debugged. Instead, one needs to run the code that should be debugged via a call to `DebugAdapter.debug_code` like this:
 

--- a/src/debugger_requests.jl
+++ b/src/debugger_requests.jl
@@ -45,13 +45,13 @@ function configuration_done_request(debug_session::DebugSession, params::Union{N
     return ConfigurationDoneResponseArguments()
 end
 
-function launch_request(debug_session::DebugSession, params::LaunchArguments)
+function launch_request(debug_session::DebugSession, params::JuliaLaunchArguments)
     # Indicate that we are ready for the initial configuration phase, and then
     # wait for it to finish
     DAPRPC.send(debug_session.endpoint, initialized_notification_type, InitializedEventArguments())
     take!(debug_session.configuration_done)
 
-    params.juliaEnv!==missing && Pkg.activate(params.juliaEnv)
+    params.project!==missing && Pkg.activate(params.project)
 
     empty!(ARGS)
     if params.args!==missing

--- a/src/protocol/dap_message_defs.jl
+++ b/src/protocol/dap_message_defs.jl
@@ -6,7 +6,6 @@
     cwd::Union{Missing,String}
     env::Union{Missing,Dict{String,String}}
     project::Union{Missing,String}
-    trace::Union{Missing,Bool}
     args::Union{Missing,Vector{String}}
     compiledModulesOrFunctions::Union{Missing,Vector{String}}
     compiledMode::Union{Missing,Bool}

--- a/src/protocol/dap_message_defs.jl
+++ b/src/protocol/dap_message_defs.jl
@@ -1,3 +1,17 @@
+@dict_readable struct JuliaLaunchArguments <: Outbound
+    noDebug::Union{Missing,Bool}
+    __restart::Union{Missing,Any}
+    program::String
+    stopOnEntry::Union{Missing,Bool}
+    cwd::Union{Missing,String}
+    env::Union{Missing,Dict{String,String}}
+    project::Union{Missing,String}
+    trace::Union{Missing,Bool}
+    args::Union{Missing,Vector{String}}
+    compiledModulesOrFunctions::Union{Missing,Vector{String}}
+    compiledMode::Union{Missing,Bool}
+end
+
 @dict_readable struct JuliaAttachArguments <: Outbound
     __restart::Union{Missing,Any}
     stopOnEntry::Bool
@@ -27,7 +41,7 @@ const stopped_notification_type = DAPRPC.EventType("stopped", StoppedEventArgume
 const threads_request_type = DAPRPC.RequestType("threads", Nothing, ThreadsResponseArguments)
 const breakpointslocation_request_type = DAPRPC.RequestType("breakpointLocations", BreakpointLocationsArguments, BreakpointLocationsResponseArguments)
 const initialize_request_type = DAPRPC.RequestType("initialize", InitializeRequestArguments, Capabilities)
-const launch_request_type = DAPRPC.RequestType("launch", LaunchArguments, LaunchResponseArguments)
+const launch_request_type = DAPRPC.RequestType("launch", JuliaLaunchArguments, LaunchResponseArguments)
 const attach_request_type = DAPRPC.RequestType("attach", JuliaAttachArguments, AttachResponseArguments)
 const initialized_notification_type = DAPRPC.EventType("initialized", InitializedEventArguments)
 const configuration_done_request_type = DAPRPC.RequestType("configurationDone", Union{ConfigurationDoneArguments,Nothing}, ConfigurationDoneResponseArguments)

--- a/src/protocol/requests.jl
+++ b/src/protocol/requests.jl
@@ -28,20 +28,6 @@ end
 @dict_readable struct ConfigurationDoneArguments <: Outbound
 end
 
-@dict_readable struct LaunchArguments <: Outbound
-    noDebug::Union{Missing,Bool}
-    __restart::Union{Missing,Any}
-    program::String
-    stopOnEntry::Union{Missing,Bool}
-    cwd::Union{Missing,String}
-    env::Union{Missing,Dict{String,String}}
-    juliaEnv::Union{Missing,String}
-    trace::Union{Missing,Bool}
-    args::Union{Missing,Vector{String}}
-    compiledModulesOrFunctions::Union{Missing,Vector{String}}
-    compiledMode::Union{Missing,Bool}
-end
-
 @dict_readable struct RestartArguments <: Outbound
 end
 


### PR DESCRIPTION
Rename `juliaEnv` to `project`, rename the type to make clear it is Julia specific not generic DAP, and remove `trace` field (not clear what that is).