### PR TITLE
Harden handling of terminate request

### DIFF
--- a/src/debugger_requests.jl
+++ b/src/debugger_requests.jl
@@ -999,7 +999,9 @@ end
 function terminate_request(debug_session::DebugSession, params::TerminateArguments)
     @debug "terminate_request"
 
-    DebugEngines.execution_terminate(debug_session.debug_engine)
+    if debug_session.debug_engine!==nothing
+        DebugEngines.execution_terminate(debug_session.debug_engine)
+    end
 
     return TerminateResponseArguments()
 end


### PR DESCRIPTION
If the client sends terminate when debug_engine is Nothing DebugAdapter crashes.  This is routinely the case if client sends terminate request as an response of an terminate event.
