### PR TITLE
fix: Fix REPL crash on debugger disconnect

### DIFF
--- a/src/DAPRPC/core.jl
+++ b/src/DAPRPC/core.jl
@@ -66,7 +66,17 @@ function Base.run(x::DAPEndpoint)
         try
             for msg in x.out_msg_queue
                 if isopen(x.pipe_out)
-                    write_transport_layer(x.pipe_out, msg)
+                    try
+                        write_transport_layer(x.pipe_out, msg)
+                    catch err
+                        if err isa Base.IOError
+                            # The other end closed; stop trying to write quietly.
+                            x.status = :closed
+                            break
+                        else
+                            rethrow()
+                        end
+                    end
                 else
                     # TODO Reconsider at some point whether this should be treated as an error.
                     break


### PR DESCRIPTION
The REPL exits unexpectedly if a debugger session is disconnected (e.g., after `@enter 1+1`) because `write_transport_layer` throws an unhandled `Base.IOError` when the pipe closes.

Reproduction:

1. starting a REPL,
2. running `@enter 1+1`, and
3. disconnecting the debugger (without continuing to exit),

the REPL has a high probability of throwing an error and then exiting.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
