### PR TITLE
feat: Add optional `code` in launch/attach args

### DIFF
--- a/src/DebugEngines.jl
+++ b/src/DebugEngines.jl
@@ -305,9 +305,8 @@ function Base.run(debug_engine::DebugEngine)
     debug_engine.frame = get_next_top_level_frame(debug_engine)
 
     if debug_engine.frame === nothing
-        error("")
-        # put!(debug_engine.next_cmd, (cmd=:stop,))
-        # return LaunchResponseArguments()
+        # Start "Debug" from Code Cell
+        return
     end
 
     if debug_engine.stop_on_entry

--- a/src/debugger_requests.jl
+++ b/src/debugger_requests.jl
@@ -82,11 +82,15 @@ function launch_request(debug_session::DebugSession, params::JuliaLaunchArgument
 
         @debug "We are debugging the file $filename_to_debug."
 
-        file_content = try
-            read(filename_to_debug, String)
-        catch err
-            put!(debug_session.next_cmd, (cmd=:terminate,))
-            return DAPError("Debugger failed to read the file `$filename_to_debug`.\n\n$(sprint(showerror, err))")
+        file_content = if params.code !== missing
+            params.code
+        else
+            try
+                read(filename_to_debug, String)
+            catch err
+                put!(debug_session.next_cmd, (cmd=:terminate,))
+                return DAPError("Debugger failed to read the file `$filename_to_debug`.\n\n$(sprint(showerror, err))")
+            end
         end
 
         if params.compiledModulesOrFunctions !== missing
@@ -123,7 +127,16 @@ function attach_request(debug_session::DebugSession, params::JuliaAttachArgument
         debug_session.compiled_mode = params.compiledMode
     end
 
-    put!(debug_session.attached, true)
+    if params.code !== missing
+        filename_to_debug = if params.program !== missing
+            isabspath(params.program) ? params.program : joinpath(pwd(), params.program)
+        else
+            joinpath(pwd(), "repl_inline.jl")
+        end
+        put!(debug_session.next_cmd, (cmd=:debug, mod=Main, code=params.code, filename=filename_to_debug))
+    else
+        put!(debug_session.attached, true)
+    end
 
     return AttachResponseArguments()
 end

--- a/src/debugger_requests.jl
+++ b/src/debugger_requests.jl
@@ -131,7 +131,7 @@ function attach_request(debug_session::DebugSession, params::JuliaAttachArgument
         filename_to_debug = if params.program !== missing
             isabspath(params.program) ? params.program : joinpath(pwd(), params.program)
         else
-            joinpath(pwd(), "repl_inline.jl")
+            joinpath(pwd(), "##unknown-file.jl")
         end
         put!(debug_session.next_cmd, (cmd=:debug, mod=Main, code=params.code, filename=filename_to_debug))
     else

--- a/src/protocol/dap_message_defs.jl
+++ b/src/protocol/dap_message_defs.jl
@@ -2,6 +2,7 @@
     noDebug::Union{Missing,Bool}
     __restart::Union{Missing,Any}
     program::String
+    code::Union{Missing,String}
     stopOnEntry::Union{Missing,Bool}
     cwd::Union{Missing,String}
     env::Union{Missing,Dict{String,String}}
@@ -13,6 +14,8 @@ end
 
 @dict_readable struct JuliaAttachArguments <: Outbound
     __restart::Union{Missing,Any}
+    program::Union{Missing,String}
+    code::Union{Missing,String}
     stopOnEntry::Bool
     compiledModulesOrFunctions::Union{Missing,Vector{String}}
     compiledMode::Union{Missing,Bool}
@@ -49,6 +52,7 @@ const terminated_notification_type = DAPRPC.EventType("terminated", TerminatedEv
 @dict_readable struct DebugArguments <: Outbound
     stopOnEntry::Bool
     program::String
+    code::Union{Missing,String}
     compiledModulesOrFunctions::Union{Missing,Vector{String}}
     compiledMode::Union{Missing,Bool}
 end


### PR DESCRIPTION
julia-vscode/julia-vscode#4011

This PR adds an optional `code` parameter to launch and attach configurations, to support inline debugging scenarios where non-debugged code is replaced with newline characters, while the document itself remains unchanged.

PS: This PR also updates `DebugArguments`, but it doesn’t seem to be used in any submodule of julia-vscode.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
