### PR TITLE
fix: support JuliaInterpreter 0.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 JSON = "0.20, 0.21"
 julia = "1"
-JuliaInterpreter = "0.8.5, 0.9, 0.10"
+JuliaInterpreter = "0.8.5, 0.9, 0.10, 0.11"
 
 [targets]
 test = ["Test", "TestItemRunner"]

--- a/src/debugger_utils.jl
+++ b/src/debugger_utils.jl
@@ -27,7 +27,7 @@ function calls_on_line(frame::JuliaInterpreter.Frame, line=nothing)
     src = frame.framecode.src
 
     exprs = []
-    for pc in frame.pc:length(src.codelocs)
+    for pc in frame.pc:length(src.code)
         loc = JuliaInterpreter.whereis(frame, pc)
 
         if loc === nothing || loc[2] > line
@@ -85,7 +85,7 @@ calls_in_frame(state) = calls_in_frame(state.debug_engine.frame)
 calls_in_frame(::Nothing) = []
 function calls_in_frame(frame::JuliaInterpreter.Frame)
     exprs = []
-    for pc in frame.pc:length(frame.framecode.src.codelocs)
+    for pc in frame.pc:length(frame.framecode.src.code)
         expr = JuliaInterpreter.pc_expr(frame, pc)
         if Meta.isexpr(expr, :call)
             push!(exprs, (pc = pc, expr = expr))


### PR DESCRIPTION
Extend the compat bound to allow JuliaInterpreter 0.11 and stop reading the `codelocs` field of `CodeInfo`, which was removed in Julia 1.12. `calls_on_line` and `calls_in_frame` now bound their pc iteration with `length(src.code)`, which is equivalent (one entry per statement) and available on all supported Julia versions.
